### PR TITLE
Feature vm spec labels annotations

### DIFF
--- a/pkg/builder/vm.go
+++ b/pkg/builder/vm.go
@@ -91,6 +91,25 @@ func (v *VMBuilder) Name(name string) *VMBuilder {
 	return v
 }
 
+func (v *VMBuilder) SpecTemplateAnnotations(annotations map[string]string) *VMBuilder {
+	if v.vm.Spec.Template.ObjectMeta.Annotations == nil {
+		v.vm.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
+	}
+	for key, val := range annotations {
+		v.vm.Spec.Template.ObjectMeta.Annotations[key] = val
+	}
+	return v
+}
+func (v *VMBuilder) SpecTemplateLabels(annotations map[string]string) *VMBuilder {
+	if v.vm.Spec.Template.ObjectMeta.Labels == nil {
+		v.vm.Spec.Template.ObjectMeta.Labels = make(map[string]string)
+	}
+	for key, val := range annotations {
+		v.vm.Spec.Template.ObjectMeta.Labels[key] = val
+	}
+	return v
+}
+
 func (v *VMBuilder) Namespace(namespace string) *VMBuilder {
 	v.vm.ObjectMeta.Namespace = namespace
 	return v


### PR DESCRIPTION
As a new feature in the the driver node for harvester, we would like to provide the ability to specify VM labels and annotations. 
This is a feature required to be able to create node templates in Rancher for nodes running CoreOS and Ignition. 

See https://github.com/harvester/harvester/issues/942